### PR TITLE
Fix virtualenv, setuptools, tests for macOS&Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 	CYTHONIZE=1 pip install .
 
 install-from-source: dist
-	pip install dist/cython-package-example-0.1.6.tar.gz
+	pip install dist/cython-package-example-0.1.7.tar.gz
 
 clean:
 	$(RM) -r build dist src/*.egg-info

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
+setuptools >= 48.0
 pytest >= 5.1
 flake8 >= 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cython-package-example
-version = 0.1.6
+version = 0.1.7
 description = Example of a package with Cython extensions
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, Extension
 
 try:
     from Cython.Build import cythonize

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,7 +1,20 @@
 from subprocess import check_output
+import sys
 from cypack.answer import zen_hash
 
 
 def test_zen_hash():
-    md5sum = check_output(["md5sum", "src/cypack/data/zen.txt"]).split(maxsplit=1)[0]
+    if sys.platform.startswith("darwin"):
+        md5sum = check_output(["md5",
+                               "src/cypack/data/zen.txt"]
+                              ).split(b'=')[-1].strip()
+    elif sys.platform.startswith("win"):
+        md5sum = check_output(["certutil",
+                               "-hashfile",
+                               r"src\cypack\data\zen.txt",
+                               "md5"]).splitlines()[1]
+    else:
+        md5sum = check_output(["md5sum",
+                               "src/cypack/data/zen.txt"]
+                              ).split(maxsplit=1)[0]
     assert md5sum == zen_hash().encode("ascii")


### PR DESCRIPTION
#5 

1. For build need setuptools, add  setuptools >= 48.0 (see PEP 632 & [Interaction of numpy.distutils with setuptools](https://numpy.org/devdocs/reference/distutils_status_migration.html#interaction-of-numpy-distutils-with-setuptools), IMHO don't need upper limit version of setuptools);
2. Replace `#!/usr/bin/python3` to `#!/usr/bin/env python3` for compatibility with piping/virtualenv/conda/mamba/...;
3. Patch `tests/test_data.py` for macOS & Windows;
4. Increment version.